### PR TITLE
Add friendly name for PKCS12

### DIFF
--- a/pkcs12.go
+++ b/pkcs12.go
@@ -657,7 +657,7 @@ func (enc *Encoder) EncodeWithFriendlyName(friendlyName string, privateKey inter
 	}
 	pkcs12Attributes := []pkcs12Attribute{localKeyIdAttr}
 
-	//asn1 values are in line with the implementation in EncodeTrustStoreEntries
+	// ASN.1 values are in line with the implementation in EncodeTrustStoreEntries
 	if len(friendlyName) != 0 {
 		bmpFriendlyName, err := bmpString(friendlyName)
 		if err != nil {

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -625,6 +625,15 @@ func Encode(rand io.Reader, privateKey interface{}, certificate *x509.Certificat
 // the end-entity certificate bag have the LocalKeyId attribute set to the SHA-1
 // fingerprint of the end-entity certificate.
 func (enc *Encoder) Encode(privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, password string) (pfxData []byte, err error) {
+	return enc.EncodeWithFriendlyName("", privateKey, certificate, caCerts, password)
+}
+
+// EncodeWithFriendlyName produces pfxData containing one private key (privateKey), an
+// end-entity certificate (certificate), and any number of CA certificates
+// (caCerts) with a friendlyName.
+//
+// If friendlyName is not empty, it will be used as the friendly name of the private key bag.
+func (enc *Encoder) EncodeWithFriendlyName(friendlyName string, privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, password string) (pfxData []byte, err error) {
 	if enc.macAlgorithm == nil && enc.certAlgorithm == nil && enc.keyAlgorithm == nil && password != "" {
 		return nil, errors.New("pkcs12: password must be empty")
 	}
@@ -646,9 +655,38 @@ func (enc *Encoder) Encode(privateKey interface{}, certificate *x509.Certificate
 	if localKeyIdAttr.Value.Bytes, err = asn1.Marshal(certFingerprint[:]); err != nil {
 		return nil, err
 	}
+	pkcs12Attributes := []pkcs12Attribute{localKeyIdAttr}
+
+	if len(friendlyName) != 0 {
+		bmpFriendlyName, err := bmpString(friendlyName)
+		if err != nil {
+			return nil, err
+		}
+
+		encodedFriendlyName, err := asn1.Marshal(asn1.RawValue{
+			Class:      0,
+			Tag:        30,
+			IsCompound: false,
+			Bytes:      bmpFriendlyName,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		friendlyNameAttr := pkcs12Attribute{
+			Id: oidFriendlyName,
+			Value: asn1.RawValue{
+				Class:      0,
+				Tag:        17,
+				IsCompound: true,
+				Bytes:      encodedFriendlyName,
+			},
+		}
+		pkcs12Attributes = append(pkcs12Attributes, friendlyNameAttr)
+	}
 
 	var certBags []safeBag
-	if certBag, err := makeCertBag(certificate.Raw, []pkcs12Attribute{localKeyIdAttr}); err != nil {
+	if certBag, err := makeCertBag(certificate.Raw, pkcs12Attributes); err != nil {
 		return nil, err
 	} else {
 		certBags = append(certBags, *certBag)
@@ -680,7 +718,7 @@ func (enc *Encoder) Encode(privateKey interface{}, certificate *x509.Certificate
 			return nil, err
 		}
 	}
-	keyBag.Attributes = append(keyBag.Attributes, localKeyIdAttr)
+	keyBag.Attributes = append(keyBag.Attributes, pkcs12Attributes...)
 
 	// Construct an authenticated safe with two SafeContents.
 	// The first SafeContents is encrypted and contains the cert bags.

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -657,6 +657,7 @@ func (enc *Encoder) EncodeWithFriendlyName(friendlyName string, privateKey inter
 	}
 	pkcs12Attributes := []pkcs12Attribute{localKeyIdAttr}
 
+	//asn1 values are in line with the implementation in EncodeTrustStoreEntries
 	if len(friendlyName) != 0 {
 		bmpFriendlyName, err := bmpString(friendlyName)
 		if err != nil {

--- a/pkcs12_test.go
+++ b/pkcs12_test.go
@@ -105,7 +105,7 @@ func TestEncoder_EncodeWithoutFriendlyName(t *testing.T) {
 
 		blocks, err := ToPEM(pfxData, "test")
 		if err != nil {
-			t.Errorf("err while reading P12 bask to PEM: %v", err)
+			t.Errorf("err while reading P12 back to PEM: %v", err)
 		}
 
 		for _, p := range blocks {

--- a/pkcs12_test.go
+++ b/pkcs12_test.go
@@ -78,7 +78,7 @@ func TestEncoder_EncodeWithFriendlyName(t *testing.T) {
 
 		blocks, err := ToPEM(pfxData, "test")
 		if err != nil {
-			t.Errorf("err while reading P12 bask to PEM: %v", err)
+			t.Errorf("err while reading P12 back to PEM: %v", err)
 		}
 
 		for _, p := range blocks {

--- a/pkcs12_test.go
+++ b/pkcs12_test.go
@@ -62,6 +62,60 @@ func TestPEM(t *testing.T) {
 	}
 }
 
+func TestEncoder_EncodeWithFriendlyName(t *testing.T) {
+	for commonName, base64P12 := range testdata {
+		p12, _ := base64.StdEncoding.DecodeString(base64P12)
+
+		key, certificate, certs, err := DecodeChain(p12, "")
+		if err != nil {
+			t.Fatalf("error while reading: %s", err)
+		}
+
+		pfxData, err := Modern.EncodeWithFriendlyName(commonName, key, certificate, certs, "test")
+		if err != nil {
+			t.Errorf("err while encoding as P12: %v", err)
+		}
+
+		blocks, err := ToPEM(pfxData, "test")
+		if err != nil {
+			t.Errorf("err while reading P12 bask to PEM: %v", err)
+		}
+
+		for _, p := range blocks {
+			if commonName != p.Headers["friendlyName"] {
+				t.Fatalf("Friendly name expected %s got %s", commonName, p.Headers["friendlyName"])
+			}
+		}
+	}
+}
+
+func TestEncoder_EncodeWithoutFriendlyName(t *testing.T) {
+	for _, base64P12 := range testdata {
+		p12, _ := base64.StdEncoding.DecodeString(base64P12)
+
+		key, certificate, certs, err := DecodeChain(p12, "")
+		if err != nil {
+			t.Fatalf("error while reading: %s", err)
+		}
+
+		pfxData, err := Modern.Encode(key, certificate, certs, "test")
+		if err != nil {
+			t.Errorf("err while encoding as P12: %v", err)
+		}
+
+		blocks, err := ToPEM(pfxData, "test")
+		if err != nil {
+			t.Errorf("err while reading P12 bask to PEM: %v", err)
+		}
+
+		for _, p := range blocks {
+			if _, ok := p.Headers["friendlyName"]; ok {
+				t.Fatalf("Friendly name not expected but got %s", p.Headers["friendlyName"])
+			}
+		}
+	}
+}
+
 func TestTrustStore(t *testing.T) {
 	for commonName, base64P12 := range testdata {
 		p12, _ := base64.StdEncoding.DecodeString(base64P12)


### PR DESCRIPTION
Adding friendly names for PKCS12. This is a much requested feature and it would enable a lot of projects to add the friendly names to PKCS12. 

Issues: 

1. https://github.com/SSLMate/go-pkcs12/issues/34 
2. https://github.com/cert-manager/cert-manager/issues/7066